### PR TITLE
Clarify GitHub hosting & pull requests.

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -90,7 +90,7 @@
 
 
 			<div class="thirteen columns offset-by-three">
-				<p>This Blue Button+ guidance was developed though <a href="http://www.healthit.gov/newsroom/about-onc">ONC’s</a> <a href="http://wiki.siframework.org/Automate+Blue+Button+Initiative">Standards and Interoperability Framework</a> initiative with input from more than 70 organizations. These docs are hosted on <a href="http://github.com">GitHub</a>, if you have any suggestions create a <a href="https://github.com/blue-button/docs/compare/">Pull Request</a>.</p>
+				<p>This Blue Button+ guidance was developed though <a href="http://www.healthit.gov/newsroom/about-onc">ONC’s</a> <a href="http://wiki.siframework.org/Automate+Blue+Button+Initiative">Standards and Interoperability Framework</a> initiative with input from more than 70 organizations. These docs are hosted on <a href="https://github.com/blue-button/docs">GitHub</a>, if you have any suggestions create a <a href="https://help.github.com/articles/using-pull-requests">Pull Request</a>.</p>
 			</div>
 
 	</div><!-- container -->


### PR DESCRIPTION
Link directly to the repository URL and provide a help link instead of a link placeholder.

-Ron
